### PR TITLE
30_受講生情報更新処理の実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -70,7 +70,7 @@ public class StudentController {
   @GetMapping("/editStudent")
   public String editStudent(@RequestParam("id") String id, Model model) {
     Student student = service.searchById(id);
-    List<StudentCourses> studentCourses = service.searchCoursesById(id);
+    List<StudentCourses> studentCourses = service.searchCoursesByStudentId(id);
 
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
@@ -78,6 +78,16 @@ public class StudentController {
 
     model.addAttribute("studentDetail", studentDetail);
     return "editStudent";
+  }
+
+  // 更新フォームのPOST送信先URL
+  @PostMapping("/updateStudent")
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result){
+    if (result.hasErrors()){
+      return "editStudent";
+    }
+    service.updateStudent(studentDetail);
+    return "redirect:/studentList";
   }
 
 

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.controller.converter.StudentConverter;
 import raisetech.student.management.data.Student;
@@ -46,7 +47,8 @@ public class StudentController {
     return "studentCourseList";
   }
 
-  @GetMapping("/newStudent") // 登録フォーム画面表示のURL
+  // 登録フォーム画面表示のURL
+  @GetMapping("/newStudent")
   public String newStudent(Model model) {
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudentCourses(Arrays.asList(new StudentCourses()));
@@ -54,18 +56,28 @@ public class StudentController {
     return "registerStudent";
   }
 
-  @PostMapping("/registerStudent") // 登録フォームのPOST送信先URL
+  // 登録フォームのPOST送信先URL
+  @PostMapping("/registerStudent")
   public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
     if (result.hasErrors()) {
       return "registerStudent";
     }
-
-    // 課題28①　新規受講生情報を登録する処理を実装する。→登録された受講生情報がstudentListとして画面表示されるところまで確認する。
-    // 課題28②　コース情報も一緒に登録できるように実装する。コースは単体でよい。→同様に画面表示まで確認する。
-
-    // 学生情報を登録
     service.registerStudent(studentDetail);
     return "redirect:/studentList";
+  }
+
+  // 更新フォーム画面表示のURL
+  @GetMapping("/editStudent")
+  public String editStudent(@RequestParam("id") String id, Model model) {
+    Student student = service.searchById(id);
+    List<StudentCourses> studentCourses = service.searchCoursesById(id);
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+    studentDetail.setStudentCourses(studentCourses);
+
+    model.addAttribute("studentDetail", studentDetail);
+    return "editStudent";
   }
 
 

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourses;
 import raisetech.student.management.domain.StudentDetail;
@@ -56,6 +57,15 @@ public interface StudentRepository {
   /**
    * 受講生情報を更新
    */
+  @Update("UPDATE students SET name = #{name}, kana_name = #{kanaName}, nickname = #{nickname}, email = #{email}, area = #{area}, "
+      + "age = #{age}, sex = #{sex}, remark = #{remark}, isDeleted = false  WHERE id = #{id}")
+  void updateStudent(Student student);
 
+  /**
+   * 受講生コース情報を更新
+   */
+  @Update("UPDATE student_courses SET course_name = #{courseName}, "
+      + "start_date = #{startDate}, end_date = #{endDate}  WHERE id = #{id}")
+  void updateStudentCourses(StudentCourses studentCourses);
 
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -7,25 +7,34 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourses;
+import raisetech.student.management.domain.StudentDetail;
 
 /**
- * 受講生情報を扱うリポジトリ。
- * <p>
- * 全件検索や単一条件での検索、コース情報の検索が行えるクラスです。
+ * 受講生情報を扱うリポジトリ。 全件検索や単一条件での検索、コース情報の検索が行えるクラスです。
  */
 @Mapper
 public interface StudentRepository {
 
   /**
-   * 全件検索します。
-   *
-   * @return 全件検索した受講生情報の一覧
+   * 全件検索した受講生情報の一覧
    */
   @Select("SELECT * FROM students")
   List<Student> search();
 
   @Select("SELECT * FROM student_courses")
   List<StudentCourses> searchCourses();
+
+  /**
+   * 特定条件での受講生情報の一覧
+   */
+  @Select("SELECT * FROM students WHERE id = #{id}")
+  Student searchById(String id);
+
+  /**
+   * 特定条件での受講生コース情報の一覧
+   */
+  @Select("SELECT * FROM student_courses WHERE student_id = #{studentId}")
+  List<StudentCourses> searchCoursesByStudentId(String studentId);
 
   /**
    * 受講生情報を登録
@@ -43,5 +52,10 @@ public interface StudentRepository {
       + "VALUES(#{studentId},#{courseName},#{startDate},#{endDate})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void registerStudentCourses(StudentCourses studentCourses);
+
+  /**
+   * 受講生情報を更新
+   */
+
 
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -37,13 +37,12 @@ public class StudentService {
   }
 
   // 特定id取得用メソッド【受講生コース情報】
-  public List<StudentCourses> searchCoursesById(String studentId) {
+  public List<StudentCourses> searchCoursesByStudentId(String studentId) {
     return repository.searchCoursesByStudentId(studentId);
   }
 
 
   @Transactional // 登録・更新・削除したりする場合は、Service層で必ずつける！
-
   // TODO:登録用メソッド【受講生情報】
   public void registerStudent(StudentDetail studentDetail) {
     repository.registerStudent(studentDetail.getStudent());
@@ -54,6 +53,20 @@ public class StudentService {
       studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
       repository.registerStudentCourses(studentCourse);
     }
+  }
+
+  @Transactional
+  // TODO:更新用メソッド【受講生情報】
+  public void updateStudent(StudentDetail studentDetail) {
+    repository.updateStudent(studentDetail.getStudent());
+    // TODO:更新用メソッド【受講生コース情報】
+    for (StudentCourses studentCourse : studentDetail.getStudentCourses()) {
+      studentCourse.setStudentId(studentDetail.getStudent().getId());
+      studentCourse.setStartDate(LocalDateTime.now());
+      studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+      repository.updateStudentCourses(studentCourse);
+    }
+
   }
 
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -31,13 +31,23 @@ public class StudentService {
     return repository.searchCourses();
   }
 
+  // 特定id取得用メソッド【受講生情報】
+  public Student searchById(String id) {
+    return repository.searchById(id);
+  }
+
+  // 特定id取得用メソッド【受講生コース情報】
+  public List<StudentCourses> searchCoursesById(String studentId) {
+    return repository.searchCoursesByStudentId(studentId);
+  }
+
 
   @Transactional // 登録・更新・削除したりする場合は、Service層で必ずつける！
 
   // TODO:登録用メソッド【受講生情報】
   public void registerStudent(StudentDetail studentDetail) {
     repository.registerStudent(studentDetail.getStudent());
-  // TODO:登録用メソッド【受講生コース情報】
+    // TODO:登録用メソッド【受講生コース情報】
     for (StudentCourses studentCourse : studentDetail.getStudentCourses()) {
       studentCourse.setStudentId(studentDetail.getStudent().getId());
       studentCourse.setStartDate(LocalDateTime.now());

--- a/src/main/resources/templates/editStudent.html
+++ b/src/main/resources/templates/editStudent.html
@@ -47,6 +47,7 @@
     　　<input type="text" id="remark" th:field="*{student.remark}" required/><br>
   </div>
   <div th:each="course, stat : *{studentCourses}">
+       <input type="hidden" th:field="*{studentCourses[__${stat.index}__].id}"/>
     　　<label for="courseName"
              th:for="studentCourse.__${stat.index}__.courseName">受講コース名:</label>
     　　<input type="text" id="courseName" th:id="studentCourse.__${stat.index}__.courseName"

--- a/src/main/resources/templates/editStudent.html
+++ b/src/main/resources/templates/editStudent.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生更新</title>
+</head>
+
+<body>
+<h1>受講生更新</h1>
+
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <!-- IDはhiddenで送信する（更新対象の指定に必須） -->
+    　<label for="id">ID:</label>
+    　<input type="hidden" id="id" th:field="*{student.id}" required/><br>
+  </div>
+  <div>
+    　　<label for="name">名前:</label>
+    　　<input type="text" id="name" th:field="*{student.name}" required/><br>
+  </div>
+  <div>
+    　　<label for="kanaName">カナ名:</label>
+    　　<input type="text" id="kanaName" th:field="*{student.kanaName}" required/><br>
+  </div>
+  <div>
+    　　<label for="nickname">ニックネーム:</label>
+    　　<input type="text" id="nickname" th:field="*{student.nickname}" required/><br>
+  </div>
+  <div>
+    　　<label for="email">メールアドレス:</label>
+    　　<input type="text" id="email" th:field="*{student.email}" required/><br>
+  </div>
+  <div>
+    　　<label for="area">地域:</label>
+    　　<input type="text" id="area" th:field="*{student.area}" required/><br>
+  </div>
+  <div>
+    　　<label for="age">年齢:</label>
+    　　<input type="text" id="age" th:field="*{student.age}"/><br>
+  </div>
+  <div>
+    　　<label for="sex">性別:</label>
+    　　<input type="text" id="sex" th:field="*{student.sex}"/><br>
+  </div>
+  <div>
+    　　<label for="remark">備考:</label>
+    　　<input type="text" id="remark" th:field="*{student.remark}" required/><br>
+  </div>
+  <div th:each="course, stat : *{studentCourses}">
+    　　<label for="courseName"
+             th:for="studentCourse.__${stat.index}__.courseName">受講コース名:</label>
+    　　<input type="text" id="courseName" th:id="studentCourse.__${stat.index}__.courseName"
+             th:field="*{studentCourses[__${stat.index}__].courseName}"/>
+  </div>
+
+  <div>
+    <button type="submit">更新</button>
+  </div>
+
+</form>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -32,6 +32,8 @@
     <td th:text="${studentDetail.student.age}">年齢</td>
     <td th:text="${studentDetail.student.sex}">性別</td>
     <td th:text="${studentDetail.student.remark}">備考</td>
+    <!-- 編集リンク：クリックするとその受講生のIDをGETパラメータとして編集画面に飛ぶ -->
+    <td><a th:href="@{/editStudent(id=${studentDetail.student.id})}">編集</a></td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## 実装内容
- 受講生情報の更新処理を実装。
- 具体的には下記を追記。
 [studentList.html] 受講生情報一覧表示画面に「編集」ボタンを追加。ここから編集作業がスタート。
 [editStudent.html] 編集したい受講生情報を更新するフォームの表示画面。
　　　　　　　　 登録フォームと同様、コース名も更新できるようにしている。
 [Contoroller層] @GetMapping("/editStudent") ← 更新フォーム画面表示のURL
　　　　　　　 @PostMapping("/updateStudent") ← 更新フォームで入力した情報の送信先URL
 [Service層] searchById(String id) ← 特定ID取得用メソッド（受講生情報）
　　　　　searchCoursesByStudentId(String studentId) ← 特定ID取得用メソッド（コース情報）　　　　　 
　　　　　updateStudent(StudentDetail studentDetail) ← 更新用メソッド（受講生情報＆コース情報）
 [Repository層] @UpdateのSQL（受講生情報とコース情報の各々）


                   

## 動作確認
### ①一覧画面　「編集」ボタンを押すことでスタート。
<img width="1089" height="416" alt="①" src="https://github.com/user-attachments/assets/d654bea0-cc10-44a0-a7d6-b112328f4b43" />

### ②【更新前】「編集」ボタンを押した後に移行する編集フォーム画面。今回はID「5」の受講生情報を更新する。
<img width="472" height="526" alt="②" src="https://github.com/user-attachments/assets/81fff5ad-68d5-46f7-8218-15b574efd04a" />

### ③【更新後】「地域」「年齢」「受講コース名（２つ目）」を更新した。
<img width="470" height="519" alt="③" src="https://github.com/user-attachments/assets/acfb48c1-1727-4352-a941-27d7961d8a5e" />

### ④更新後の受講生情報一覧の画面。
<img width="1086" height="417" alt="④" src="https://github.com/user-attachments/assets/7ee85195-7522-47ed-8504-198d22848bff" />

### ⑤コース情報のDB（上：更新前、下：更新後）　※student_idが「5」の情報が更新されている。
<img width="817" height="261" alt="⑤" src="https://github.com/user-attachments/assets/74f3d003-185d-4d5c-9035-32474415fe87" />
<img width="819" height="261" alt="⑥" src="https://github.com/user-attachments/assets/5d2a8a0f-83d7-479d-b191-1f8115c4533b" />


## 工夫した点・学んだこと
- 時間はかかったが、ベースは登録処理を模したコードで実装可能だったため、手も足も出ないということにはならなかった。受講生情報のみならば更新実装はそれほど難しくなかった。
- コース情報も更新しようとする場合に、複数の受講コースの各々に対して「開始日」「終了日」を更新すべきと思われるが、うまく実装する方法が分からなかった。（今回ケースでは、１つ目のコース情報は更新せず、２つ目のコース情報を更新するみたいなことをするのが現実的であるが、両コースとも同じ「開始日」「終了日」で更新されている。）