### PR TITLE
31_受講生情報削除処理の実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -87,7 +87,7 @@ public class StudentController {
       return "updateStudent";
     }
     service.updateStudent(studentDetail);
-    return "redirect:/studentList";
+    return "redirect:/activeStudentList";
   }
 
 

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -42,6 +42,16 @@ public class StudentController {
     return "studentList";
   }
 
+  // 有効（非削除）受講生の画面表示のURL
+  @GetMapping("/activeStudentList")
+  public String getActiveStudentList(Model model) {
+    List<Student> students = service.searchActiveStudentList();
+    List<StudentCourses> studentCourses = service.searchStudentCoursesList();
+
+    model.addAttribute("activeStudentList", converter.convertstudentdetails(students, studentCourses));
+    return "activeStudentList";
+  }
+
   // 特定idの受講生の更新フォーム画面表示のURL
   @GetMapping("/student/{id}")
   public String getStudent(@PathVariable String id, Model model) {

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -16,5 +16,5 @@ public class Student {
   private Integer age;
   private String sex;
   private String remark;
-  private boolean isDeleted;
+  private Boolean isDeleted;
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -17,10 +17,14 @@ public interface StudentRepository {
 
   /**
    * 全件検索した受講生情報の一覧
+   * 有効（非削除）の受講生情報の一覧
    * 特定idの受講生情報の一覧
    */
   @Select("SELECT * FROM students")
   List<Student> search();
+
+  @Select("SELECT * FROM students WHERE isDeleted = false")
+  List<Student> searchActiveStudentList();
 
   @Select("SELECT * FROM students WHERE id = #{id}")
   Student searchStudent(String id);

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -25,6 +25,11 @@ public class StudentService {
     return repository.search();
   }
 
+  // 有効（非削除）の一覧取得用メソッド【受講生情報】
+  public List<Student> searchActiveStudentList() {
+    return repository.searchActiveStudentList();
+  }
+
   // 一覧取得用メソッド【受講生コース情報】
   public List<StudentCourses> searchStudentCoursesList() {
     return repository.searchStudentCoursesList();

--- a/src/main/resources/templates/activeStudentList.html
+++ b/src/main/resources/templates/activeStudentList.html
@@ -26,7 +26,7 @@
     <td th:text="${studentDetail.student.id}">ID</td>
     <td>
     <!-- 編集リンク：「名前」にリンクをつけ、クリックするとその受講生のIDをGETパラメータとして編集画面に飛ぶ -->
-      <a href="/studentList" th:href="@{/student/{id}(id=${studentDetail.student.id})}"
+      <a href="/activeStudentList" th:href="@{/student/{id}(id=${studentDetail.student.id})}"
          th:text="${studentDetail.student.name}">名前</a>
     </td>
     <td th:text="${studentDetail.student.kanaName}">カナ名</td>

--- a/src/main/resources/templates/activeStudentList.html
+++ b/src/main/resources/templates/activeStudentList.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生一覧【有効】</title>
+</head>
+<body>
+<h1>受講生情報一覧【有効】</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>カナ名</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <!-- studentListから1人ずつ取り出し -->
+  <tr th:each="studentDetail: ${activeStudentList}">
+    <td th:text="${studentDetail.student.id}">ID</td>
+    <td>
+    <!-- 編集リンク：「名前」にリンクをつけ、クリックするとその受講生のIDをGETパラメータとして編集画面に飛ぶ -->
+      <a href="/studentList" th:href="@{/student/{id}(id=${studentDetail.student.id})}"
+         th:text="${studentDetail.student.name}">名前</a>
+    </td>
+    <td th:text="${studentDetail.student.kanaName}">カナ名</td>
+    <td th:text="${studentDetail.student.nickname}">ニックネーム</td>
+    <td th:text="${studentDetail.student.email}">メール</td>
+    <td th:text="${studentDetail.student.area}">地域</td>
+    <td th:text="${studentDetail.student.age}">年齢</td>
+    <td th:text="${studentDetail.student.sex}">性別</td>
+    <td th:text="${studentDetail.student.remark}">備考</td>
+  </tr>
+  </tbody>
+</table>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -56,6 +56,12 @@
              th:field="*{studentCourses[__${stat.index}__].courseName}"/>
   </div>
 
+  <!-- isiDeletedの削除フラグを追加 -->
+  <div>
+    　　<label for="isDeleted">削除済み？:</label>
+    　　<input type="checkbox" id="isDeleted" th:field="*{student.isDeleted}" /><br>
+  </div>
+
   <div>
     <button type="submit">更新</button>
   </div>


### PR DESCRIPTION
## 実装内容
- 受講生情報削除処理の実装
- 具体的には以下の処理を追記
[ Controller層 ] @GetMapping("/activeStudentList)　👈有効データList（論理削除でfalse）の受講生情報を表示
[ activeStudentList.html ] 　👈有効データの表示画面html（コードはstudentList.htmlの写し）
[ updateStudent.html ]　👈「isDeleted」の削除チェックボックスを追加
[ Service層、Repository層 ]　👈有効データListの一覧取得処理を追加

## 動作確認
#### ①初期の受講生情報DB（いずれも論理削除はfalse）
<img width="1729" height="245" alt="①" src="https://github.com/user-attachments/assets/063817c7-30bc-40cb-90a9-adbfda36b2e7" />

#### ②有効データの画面表示【/activeStudentlistにリンク】
<img width="906" height="370" alt="②" src="https://github.com/user-attachments/assets/0d9348f4-60d4-42b7-9caa-1eefc309b25d" />

#### ③受講生ID「18」の編集URLへリンク後
<img width="724" height="462" alt="③" src="https://github.com/user-attachments/assets/51d0635e-23d9-4c4c-8559-3fc899d2059d" />

#### ④ ③のリンク後に「削除済み？」チェックボックスにチェック→「更新」ボタンを押す
<img width="725" height="454" alt="④" src="https://github.com/user-attachments/assets/36e40682-709d-443f-8fe0-6b65b8f293e8" />

#### ⑤ ④の処理後に、受講生情報一覧に飛ぶ（redirect先を/studentListにしているので、削除データも表示されている）
<img width="909" height="373" alt="⑤" src="https://github.com/user-attachments/assets/aaf182a8-c751-48ac-9197-fbce48559e86" />

#### ⑥ 有効データの画面表示【/activeStudentlistにリンク】→受講生ID「18」の情報は消えている。　※アドレスバーに手入力でURLリンクしています
<img width="907" height="344" alt="⑥" src="https://github.com/user-attachments/assets/d40327ac-097c-43be-a3e8-a1b1891ca1c0" />

#### ⑦処理後の受講生情報DB（ID「18」受講生の論理削除がtrue）
<img width="1735" height="248" alt="⑦" src="https://github.com/user-attachments/assets/e124fc7c-bf01-445d-aaba-00db8192ec75" />

## 工夫した点・学んだこと
- いつもはChatGPTに頼りがちだが、今回の削除処理は更新処理の延長上でできた（はず）ので、AIへの確認は最小限で済んだ。
- ④でせっかく削除したのに、⑤で結局、削除データ含めての一覧表示に戻るのはナンセンスな気もするので、[ Controller層 ]の@PostMapping("/updateStudent") にて、リダイレクト先を、/activeStudentList に修正すべき？　もしくはもう１つ@PostMappinを作るべき？
- 改めて今まで記述してきたクラス層や各コードに立ち返ると、画面バーに収まりきらないクラス数に加え、StudentDetailやconverter等の２つの情報（受講生、コース）を合併させる処理が組み込まれているため、頭の中がかなりいっぱいになっている印象。

