### PR TITLE
EC2のIPアドレスを更新

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   EC2_USER: 'ec2-user'
-  EC2_HOST: '57.180.37.65'
+  EC2_HOST: '54.199.209.184'
   SRC_PATH: 'build/libs/*.jar'
   DEST_PATH: '/home/ec2-user/StudentManagement.jar'
 


### PR DESCRIPTION
- GitHub Actionsで使用するEC2のパブリックIPを新しいものに更新しました。
- CDが正常に動作するか確認のためのテストPRです。